### PR TITLE
Fix closure capture warnings

### DIFF
--- a/Shakedown Shuffle/Shakedown Shuffle/DatabaseManager.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/DatabaseManager.swift
@@ -17,7 +17,7 @@ class DatabaseManager {
             logger.info("Found show_categories.json in bundle")
             let data = try Data(contentsOf: categoriesURL)
             showCategories = try ShowCategoriesModel(data: data)
-            logger.info("Loaded show categories: \(showCategories?.categories.byYear.count ?? 0) years")
+            logger.info("Loaded show categories: \(self.showCategories?.categories.byYear.count ?? 0) years")
         } else {
             // Try loading from the project directory
             let projectPath = Bundle.main.bundlePath
@@ -33,7 +33,7 @@ class DatabaseManager {
             logger.info("Found enriched_shows.json in bundle")
             let data = try Data(contentsOf: enrichedURL)
             enrichedShows = try JSONDecoder().decode(EnrichedShowsData.self, from: data)
-            logger.info("Loaded enriched shows: \(enrichedShows?.bestShows.count ?? 0) shows")
+            logger.info("Loaded enriched shows: \(self.enrichedShows?.bestShows.count ?? 0) shows")
         } else {
             // Try loading from the project directory
             let projectPath = Bundle.main.bundlePath

--- a/Shakedown Shuffle/Shakedown Shuffle/ViewModels/ShowViewModel.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/ViewModels/ShowViewModel.swift
@@ -83,7 +83,7 @@ class ShowViewModel: ObservableObject {
         currentShow = show
         currentDate = show.identifier
         isFavorited = historyManager.isFavorite(show)
-        logger.info("Set show \(show.identifier), favorite status: \(isFavorited)")
+        logger.info("Set show \(show.identifier), favorite status: \(self.isFavorited)")
         
         Task {
             do {
@@ -110,7 +110,7 @@ class ShowViewModel: ObservableObject {
         currentShow = show
         currentDate = show.identifier
         isFavorited = historyManager.isFavorite(show)
-        logger.info("Set show \(show.identifier) without auto-play, favorite status: \(isFavorited)")
+        logger.info("Set show \(show.identifier) without auto-play, favorite status: \(self.isFavorited)")
         
         Task {
             do {


### PR DESCRIPTION
## Summary
- explicitly reference `self.showCategories` and `self.enrichedShows` in logger messages
- keep `self.isFavorited` references in ShowViewModel logging

## Testing
- `git status --short`
