### PR TITLE
Fix YouTube URLs and keep playback

### DIFF
--- a/Shakedown Shuffle/Shakedown Shuffle/Views/Common/WebView.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/Views/Common/WebView.swift
@@ -91,10 +91,14 @@ struct WebViewContainer: View {
     @StateObject private var coordinator: WebViewCoordinator
     @Environment(\.dismiss) private var dismiss
     @State private var timeoutTimerActive = true
-    
-    init(url: URL) {
+
+    init(url: URL, coordinator: WebViewCoordinator? = nil) {
         self.url = url
-        self._coordinator = StateObject(wrappedValue: WebViewCoordinator(url: url))
+        if let coord = coordinator {
+            self._coordinator = StateObject(wrappedValue: coord)
+        } else {
+            self._coordinator = StateObject(wrappedValue: WebViewCoordinator(url: url))
+        }
     }
     
     // Function to open URL in Safari

--- a/Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/YouTubePlayerView.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/YouTubePlayerView.swift
@@ -7,7 +7,7 @@ struct YouTubePlayerView: View {
     var body: some View {
         VStack {
             if let url = show.youtubeURL {
-                WebViewContainer(url: url)
+                WebViewContainer(url: url, coordinator: viewModel.coordinator)
                     .frame(height: 300)
             } else {
                 Text("Invalid video URL")
@@ -28,14 +28,14 @@ struct YouTubePlayerView: View {
             viewModel.play(show: show)
         }
         .onDisappear {
-            viewModel.stopPlayback()
+            // Keep playback running when navigating away
         }
     }
 }
 
 #Preview {
     NavigationStack {
-        let demo = YouTubeShowViewModel.YouTubeShow(id: "1", date: "1/1/2000", venue: "Venue", location: "City, ST", name: "Demo", videoID: "dQw4w9WgXcQ")
+        let demo = YouTubeShowViewModel.YouTubeShow(id: "1", date: "1/1/2000", venue: "Venue", location: "City, ST", name: "Demo", urlString: "https://youtube.com/watch?v=dQw4w9WgXcQ")
         YouTubePlayerView(show: demo)
     }
 }


### PR DESCRIPTION
## Summary
- update YouTube view model to store URL strings
- persist `WKWebView` coordinator and reuse it
- update `WebViewContainer` to accept an external coordinator
- keep YouTube playback running when navigating away

## Testing
- `swift build -v` *(fails: Could not find Package.swift)*
- `swift test -v` *(fails: Could not find Package.swift)*