### PR TITLE
Fix floating YouTube player position

### DIFF
--- a/Shakedown Shuffle/Shakedown Shuffle/Shakedown_ShuffleApp.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/Shakedown_ShuffleApp.swift
@@ -12,7 +12,7 @@ struct Shakedown_ShuffleApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ZStack {
+            ZStack(alignment: .bottomTrailing) {
                 if isLoading {
                     SplashScreenView()
                 } else {


### PR DESCRIPTION
## Summary
- keep the YouTube mini player anchored to the corner so it no longer obscures the main views

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*