### PR TITLE
Improve YouTube playback handling

### DIFF
--- a/Shakedown Shuffle/Shakedown Shuffle/ViewModels/YouTube/YouTubeShowViewModel.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/ViewModels/YouTube/YouTubeShowViewModel.swift
@@ -106,6 +106,7 @@ struct YouTubeShow: Identifiable, Codable {
     @Published var isPlaying = false
     @Published var coordinator: WebViewCoordinator?
     @Published private(set) var favoriteShows: [YouTubeShow] = []
+    @Published var isPlayerPresented = false
 
     private init() {
         loadFavorites()
@@ -160,6 +161,16 @@ struct YouTubeShow: Identifiable, Codable {
 
     func stopPlayback() {
         isPlaying = false
+        currentShow = nil
+        coordinator = nil
+    }
+
+    func presentPlayer() {
+        isPlayerPresented = true
+    }
+
+    func dismissPlayer() {
+        isPlayerPresented = false
     }
 
     private func loadFavorites() {

--- a/Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/FloatingYouTubePlayerView.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/FloatingYouTubePlayerView.swift
@@ -6,8 +6,8 @@ struct FloatingYouTubePlayerView: View {
     @State private var showFullPlayer = false
 
     var body: some View {
-        // Show only when a video is actively playing
-        if let show = viewModel.currentShow, viewModel.isPlaying {
+        // Show only when a video is actively playing and the full player isn't visible
+        if let show = viewModel.currentShow, viewModel.isPlaying, !viewModel.isPlayerPresented {
             VStack(spacing: 0) {
                 HStack {
                     Spacer()
@@ -31,8 +31,11 @@ struct FloatingYouTubePlayerView: View {
             .cornerRadius(8)
             .shadow(radius: 5)
             .padding()
-            .sheet(isPresented: $showFullPlayer) {
+            .sheet(isPresented: $showFullPlayer, onDismiss: {
+                viewModel.dismissPlayer()
+            }) {
                 YouTubePlayerView(show: show)
+                    .onAppear { viewModel.presentPlayer() }
             }
         }
     }

--- a/Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/YouTubePlayerView.swift
+++ b/Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/YouTubePlayerView.swift
@@ -82,9 +82,10 @@ struct YouTubePlayerView: View {
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             viewModel.play(show: show)
+            viewModel.presentPlayer()
         }
         .onDisappear {
-            // Keep playback running when navigating away
+            viewModel.dismissPlayer()
         }
         .sheet(isPresented: $showingWebView) {
             if let url = show.url, let external = URL(string: url) {


### PR DESCRIPTION
## Summary
- hide floating player when full YouTube view is shown
- track full screen player state in `YouTubeShowViewModel`
- clear playback state when closing YouTube videos
- show/hide player correctly when opening from mini player

## Testing
- `swiftc -parse Shakedown Shuffle/Shakedown Shuffle/ViewModels/YouTube/YouTubeShowViewModel.swift Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/YouTubePlayerView.swift Shakedown Shuffle/Shakedown Shuffle/Views/YouTube/FloatingYouTubePlayerView.swift`